### PR TITLE
Fixed repeated docs section and current user docs bug

### DIFF
--- a/app/profile/[uid]/page.tsx
+++ b/app/profile/[uid]/page.tsx
@@ -109,10 +109,7 @@ export default function ViewProfile({ params }) {
 
       <ProfileContact email={user.email} phone={user.phone} />
 
-      <ProfileDocuments
-        resume={currentUser.resume}
-        coverLetter={currentUser.coverLetter}
-      />
+      <ProfileDocuments resume={user.resume} coverLetter={user.coverLetter} />
 
       <ProfileLanguages languages={user.languages} />
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -85,12 +85,6 @@ export default function PreviewProfile() {
       />
 
       <ProfileContact email={currentUser.email} phone={currentUser.phone} />
-      {!currentUser.isCompany && (
-        <ProfileDocuments
-          resume={currentUser.resume}
-          coverLetter={currentUser.coverLetter}
-        />
-      )}
 
       <ProfileDocuments
         resume={currentUser.resume}

--- a/components/ProfilePage/ProfileDocuments/ProfileDocuments.tsx
+++ b/components/ProfilePage/ProfileDocuments/ProfileDocuments.tsx
@@ -89,10 +89,12 @@ export default function ProfileDocuments({
 
   // Live version of documents component
   if (!isEditable) {
+    if (!resume && !coverLetter) return;
+
     //****CardStack has to output first the resume , then the coverletter*****
     return (
       <div className="mb-10">
-        <h2 className="text-2xl font-extrabold"> Docs </h2>
+        <h2 className="mb-2 text-2xl font-extrabold">Docs</h2>
         <div className="flex gap-2">
           {resume && <FileButton link={resume.link}>{resume.name}</FileButton>}
           {coverLetter && (


### PR DESCRIPTION
# Description
- Fixed issue where user's own documents would show on other users' profiles.
- Fixed issue where non-company accounts would show profile documents twice on the `/profile` page.
- A profile without documents will hide the `Docs` heading.

## Acceptance Test (optional)
- [x] Upload a document. Visit another user's profile. You should not see your own documents.
- [x] Upload a document. Visit `/profile` page. You should see the Docs section once (not twice).
- [x] With no documents uploaded in your profile, visit `/profile` or `/profile/[your userid]`. You should not see the documents section at all (no `Docs` heading).

# Development
- closes #195 
